### PR TITLE
Fix builds on Ventura M1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,8 @@ jobs:
             coverage: true
           - perl-version: '5.30'
             os: windows-latest
-          #disabled as Apple headers have `const GLvoid *` while OpenGL has `void *`
-          #- perl-version: '5.30'
-          #  os: macos-latest
+          - perl-version: '5.30'
+            os: macos-latest
     steps:
       - uses: actions/checkout@v2
       - name: 'ci-dist: target-setup-perl'

--- a/gl_util.h
+++ b/gl_util.h
@@ -8,12 +8,14 @@
 /* Include prototype flag */
 #if (defined(_WIN32) || defined(HAVE_W32API))
 #define GL_GLEXT_PROCS
-#else
+#elif !defined(HAVE_AGL_GLUT)
 #define GL_GLEXT_PROTOTYPES
 #endif
 
 /* Provide GL header files for Windows and Apple */
-#define INCLUDE_LOCAL_HEADER defined(HAVE_W32API) || defined(__APPLE__)
+#if defined(HAVE_W32API) || defined(__APPLE__)
+#define INCLUDE_LOCAL_HEADER 1
+#endif
 #if INCLUDE_LOCAL_HEADER
 #include "./include/GL/gl.h"
 #else

--- a/glext_procs.h
+++ b/glext_procs.h
@@ -1,3 +1,5 @@
+
+#ifndef HAVE_AGL_GLUT
 #ifndef __glext_procs_h_
 #define __glext_procs_h_
 
@@ -16244,3 +16246,5 @@ static PFNGLREPLACEMENTCODEUITEXCOORD2FCOLOR4FNORMAL3FVERTEX3FVSUNPROC glReplace
 #endif
 
 #endif
+
+#endif  /* HAVE_AGL_GLUT */

--- a/utils/glext_procs.pl
+++ b/utils/glext_procs.pl
@@ -25,6 +25,8 @@ foreach my $line (<EXPS>)
 }
 close(EXPS);
 
+print EXTS "\n#ifndef HAVE_AGL_GLUT\n";
+
 # Header
 my $header = qq
 {#ifndef %s
@@ -187,6 +189,8 @@ while (<FILE>)
     print TYPE $line;
   }
 }
+
+print EXTS "\n#endif  /* HAVE_AGL_GLUT */\n";
 
 close(EXTS);
 close(FILE);


### PR DESCRIPTION
On more recent releases of MacOS, several warnings and errors are emitted due to duplicate definiions when building against AGL. This commit removes the duplicate definitions with AGL, relying instead on AGL.Framework to provide them.